### PR TITLE
fix: notification cell a11y fixes, add new onMarkAllAsReadClick prop

### DIFF
--- a/src/components/NotificationCell/NotificationCell.tsx
+++ b/src/components/NotificationCell/NotificationCell.tsx
@@ -35,12 +35,28 @@ export const NotificationCell = React.forwardRef<
     // Mark as read once we click the item
     feedClient.markAsRead(item);
 
-    if (onItemClick) {
-      onItemClick(item);
-    } else {
+    if (onItemClick) return onItemClick(item);
+
+    // Delay when we navigate, until we've actually issued our API call.
+    setTimeout(() => {
       window.location.assign(actionUrl);
-    }
+    }, 200);
   }, [item]);
+
+  const onKeyDown = React.useCallback(
+    (ev: React.KeyboardEvent<HTMLDivElement>) => {
+      switch (ev.key) {
+        case "Enter": {
+          ev.stopPropagation();
+          onClick();
+          break;
+        }
+        default:
+          break;
+      }
+    },
+    [onClick]
+  );
 
   const actor = item.actors[0];
 
@@ -48,8 +64,11 @@ export const NotificationCell = React.forwardRef<
     <div
       ref={ref}
       className={`rnf-notification-cell rnf-notification-cell--${colorMode}`}
+      onClick={onClick}
+      onKeyDown={onKeyDown}
+      tabIndex={0}
     >
-      <div onClick={onClick} className="rnf-notification-cell__inner">
+      <div className="rnf-notification-cell__inner">
         {!item.read_at && <div className="rnf-notification-cell__unread-dot" />}
 
         {renderNodeOrFallback(

--- a/src/components/NotificationCell/styles.css
+++ b/src/components/NotificationCell/styles.css
@@ -46,6 +46,7 @@
 /* Notification cell */
 
 .rnf-notification-cell {
+  background-color: transparent;
   position: relative;
   border-bottom: 1px solid var(--rnf-notification-cell-border-bottom-color);
 }
@@ -54,8 +55,14 @@
   border-bottom-color: transparent;
 }
 
+.rnf-notification-cell:hover,
+.rnf-notification-cell:focus,
+.rnf-notification-cell:active {
+  background-color: var(--rnf-notification-cell-active-bg-color);
+  outline: none;
+}
+
 .rnf-notification-cell__inner {
-  background-color: transparent;
   border: none;
   appearance: none;
   margin: 0;
@@ -66,13 +73,6 @@
   cursor: pointer;
   text-align: left;
   justify-content: flex-start;
-}
-
-.rnf-notification-cell__inner:hover,
-.rnf-notification-cell__inner:focus,
-.rnf-notification-cell__inner:active {
-  background-color: var(--rnf-notification-cell-active-bg-color);
-  outline: none;
 }
 
 .rnf-notification-cell__unread-dot {
@@ -166,16 +166,20 @@
   margin-left: auto;
   color: var(--rnf-archive-notification-btn-bg-color);
   padding: var(--rnf-spacing-1) var(--rnf-spacing-2);
-  transition: color 0.1s;
+  transition: color 0.1s ease-in-out, opacity 0.2s ease-in-out;
 }
 
+.rnf-notification-cell:focus .rnf-archive-notification-btn,
 .rnf-notification-cell:hover .rnf-archive-notification-btn,
 .rnf-notification-cell:active .rnf-archive-notification-btn {
   opacity: 1;
 }
 
+.rnf-archive-notification-btn:focus,
 .rnf-archive-notification-btn:hover,
 .rnf-archive-notification-btn:active {
+  outline: none;
+  opacity: 1;
   color: var(--rnf-archive-notification-btn-bg-color-active);
 }
 
@@ -190,6 +194,7 @@
   flex-direction: column;
   padding: var(--rnf-spacing-1) var(--rnf-spacing-2);
   font-size: var(--rnf-font-size-xs);
+  line-height: var(--rnf-font-size-s);
   font-weight: var(--rnf-font-weight-medium);
   transition: opacity 0.3s;
   z-index: 9999;

--- a/src/components/NotificationFeed/MarkAsRead.tsx
+++ b/src/components/NotificationFeed/MarkAsRead.tsx
@@ -1,10 +1,15 @@
 import * as React from "react";
+import { FeedItem } from "@knocklabs/client";
 import { useKnockFeed } from "../KnockFeedProvider";
 import { CheckmarkCircle } from "../Icons";
 
 import "./styles.css";
 
-export const MarkAsRead = () => {
+export type MarkAsReadProps = {
+  onClick?: (e: React.MouseEvent, unreadItems: FeedItem[]) => void;
+};
+
+export const MarkAsRead: React.FC<MarkAsReadProps> = ({ onClick }) => {
   const { useFeedStore, feedClient, colorMode } = useKnockFeed();
 
   const unreadItems = useFeedStore((state) =>
@@ -13,15 +18,19 @@ export const MarkAsRead = () => {
 
   const unreadCount = useFeedStore((state) => state.metadata.unread_count);
 
-  const onClick = React.useCallback(() => {
-    feedClient.markAsRead(unreadItems);
-  }, [feedClient, unreadItems]);
+  const onClickHandler = React.useCallback(
+    (e: React.MouseEvent) => {
+      feedClient.markAsRead(unreadItems);
+      if (onClick) onClick(e, unreadItems);
+    },
+    [feedClient, unreadItems, onClick]
+  );
 
   return (
     <button
       className={`rnf-mark-all-as-read rnf-mark-all-as-read--${colorMode}`}
       disabled={unreadCount === 0}
-      onClick={onClick}
+      onClick={onClickHandler}
     >
       Mark all as read
       <CheckmarkCircle />

--- a/src/components/NotificationFeed/NotificationFeed.tsx
+++ b/src/components/NotificationFeed/NotificationFeed.tsx
@@ -22,6 +22,7 @@ export interface NotificationFeedProps {
   EmptyComponent?: ReactNode;
   renderItem?: RenderItem;
   onNotificationClick?: OnNotificationClick;
+  onMarkAllAsReadClick?: (e: React.MouseEvent, unreadItems: FeedItem[]) => void;
   isVisible: boolean;
 }
 
@@ -33,6 +34,7 @@ export const NotificationFeed: React.FC<NotificationFeedProps> = ({
   EmptyComponent = <EmptyFeed />,
   renderItem = defaultRenderItem,
   onNotificationClick,
+  onMarkAllAsReadClick,
   isVisible = false,
 }) => {
   const {
@@ -102,7 +104,7 @@ export const NotificationFeed: React.FC<NotificationFeedProps> = ({
             )}
           </Dropdown>
         </div>
-        <MarkAsRead />
+        <MarkAsRead onClick={onMarkAllAsReadClick} />
       </header>
 
       <div className="rnf-notification-feed__container" ref={containerRef}>

--- a/src/components/NotificationFeedPopover/NotificationFeedPopover.tsx
+++ b/src/components/NotificationFeedPopover/NotificationFeedPopover.tsx
@@ -13,47 +13,51 @@ export interface NotificationFeedPopoverProps extends NotificationFeedProps {
   closeOnClickOutside?: boolean;
 }
 
-export const NotificationFeedPopover: React.FC<NotificationFeedPopoverProps> = ({
-  isVisible,
-  onClose,
-  buttonRef,
-  closeOnClickOutside = true,
-  ...feedProps
-}) => {
-  const { colorMode } = useKnockFeed();
-  const { ref: popperRef } = useComponentVisible(isVisible, onClose, {
-    closeOnClickOutside,
-  });
+export const NotificationFeedPopover: React.FC<NotificationFeedPopoverProps> =
+  ({
+    isVisible,
+    onClose,
+    buttonRef,
+    closeOnClickOutside = true,
+    ...feedProps
+  }) => {
+    const { colorMode } = useKnockFeed();
+    const { ref: popperRef } = useComponentVisible(isVisible, onClose, {
+      closeOnClickOutside,
+    });
 
-  const { styles, attributes } = usePopper(
-    buttonRef.current,
-    popperRef.current,
-    {
-      strategy: "fixed",
-      placement: "bottom-end",
-      modifiers: [
-        {
-          name: "offset",
-          options: {
-            offset: [0, 8],
+    const { styles, attributes } = usePopper(
+      buttonRef.current,
+      popperRef.current,
+      {
+        strategy: "fixed",
+        placement: "bottom-end",
+        modifiers: [
+          {
+            name: "offset",
+            options: {
+              offset: [0, 8],
+            },
           },
-        },
-      ],
-    }
-  );
+        ],
+      }
+    );
 
-  return (
-    <div
-      className={`rnf-notification-feed-popover rnf-notification-feed-popover--${colorMode}`}
-      style={{ ...styles.popper, visibility: isVisible ? "visible" : "hidden" }}
-      ref={popperRef}
-      {...attributes.popper}
-      role="dialog"
-      tabIndex={-1}
-    >
-      <div className="rnf-notification-feed-popover__inner">
-        <NotificationFeed isVisible={isVisible} {...feedProps} />
+    return (
+      <div
+        className={`rnf-notification-feed-popover rnf-notification-feed-popover--${colorMode}`}
+        style={{
+          ...styles.popper,
+          visibility: isVisible ? "visible" : "hidden",
+        }}
+        ref={popperRef}
+        {...attributes.popper}
+        role="dialog"
+        tabIndex={-1}
+      >
+        <div className="rnf-notification-feed-popover__inner">
+          <NotificationFeed isVisible={isVisible} {...feedProps} />
+        </div>
       </div>
-    </div>
-  );
-};
+    );
+  };


### PR DESCRIPTION
* Adds new `onMarkAllAsReadClick` prop
* Improves a11y on the NotificationCell, including keyboard handling
* Fixes issue where tooltip line height gets overridden
* Fixes issue with archive button not working properly in some settings