### PR TITLE
feat: add button and button group components for actions

### DIFF
--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -1,6 +1,5 @@
 import React from "react";
 import { useKnockFeed } from "../KnockFeedProvider";
-import { Spinner } from "../Spinner";
 import { ButtonSpinner } from "./ButtonSpinner";
 
 import "./styles.css";
@@ -33,7 +32,10 @@ export const Button: React.FC<ButtonProps> = ({
     `rnf-button--${colorMode}`,
   ].join(" ");
 
-  const showWhileLoading = loadingText || (
+  // In this case when there's no loading text, we still want to display the original
+  // content of the button, but make it hidden. That allows us to keep the button width
+  // consistent and show the spinner in the middle, meaning no layout shift.
+  const textToShowWhileLoading = loadingText || (
     <span className="rnf-button__button-text-hidden">{children}</span>
   );
 
@@ -43,8 +45,8 @@ export const Button: React.FC<ButtonProps> = ({
       className={classNames}
       disabled={isLoading || isDisabled}
     >
-      {isLoading && <ButtonSpinner label={loadingText} />}
-      {isLoading ? showWhileLoading : children}
+      {isLoading && <ButtonSpinner hasLabel={!!loadingText} />}
+      {isLoading ? textToShowWhileLoading : children}
     </button>
   );
 };

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -1,0 +1,50 @@
+import React from "react";
+import { useKnockFeed } from "../KnockFeedProvider";
+import { Spinner } from "../Spinner";
+import { ButtonSpinner } from "./ButtonSpinner";
+
+import "./styles.css";
+
+export type ButtonProps = {
+  variant: "primary" | "secondary";
+  loadingText?: string;
+  isLoading?: boolean;
+  isDisabled?: boolean;
+  isFullWidth?: boolean;
+  onClick: (e: React.MouseEvent) => void;
+};
+
+export const Button: React.FC<ButtonProps> = ({
+  variant = "primary",
+  loadingText,
+  isLoading = false,
+  isDisabled = false,
+  isFullWidth = false,
+  onClick,
+  children,
+}) => {
+  const { colorMode } = useKnockFeed();
+
+  const classNames = [
+    "rnf-button",
+    `rnf-button--${variant}`,
+    isFullWidth ? "rnf-button--full-width" : "",
+    isLoading ? "rnf-button--is-loading" : "",
+    `rnf-button--${colorMode}`,
+  ].join(" ");
+
+  const showWhileLoading = loadingText || (
+    <span className="rnf-button__button-text-hidden">{children}</span>
+  );
+
+  return (
+    <button
+      onClick={onClick}
+      className={classNames}
+      disabled={isLoading || isDisabled}
+    >
+      {isLoading && <ButtonSpinner label={loadingText} />}
+      {isLoading ? showWhileLoading : children}
+    </button>
+  );
+};

--- a/src/components/Button/ButtonGroup.tsx
+++ b/src/components/Button/ButtonGroup.tsx
@@ -1,0 +1,7 @@
+import React from "react";
+
+import "./styles.css";
+
+export const ButtonGroup: React.FC = ({ children }) => (
+  <div className="rnf-button-group">{children}</div>
+);

--- a/src/components/Button/ButtonSpinner.tsx
+++ b/src/components/Button/ButtonSpinner.tsx
@@ -1,0 +1,18 @@
+import React from "react";
+import { Spinner } from "../Spinner";
+
+import "./styles.css";
+
+type ButtonSpinnerProps = {
+  label?: string;
+};
+
+export const ButtonSpinner: React.FC<ButtonSpinnerProps> = ({ label }) => (
+  <div
+    className={`rnf-button-spinner rnf-button-spinner--${
+      label ? "with-label" : "without-label"
+    }`}
+  >
+    <Spinner />
+  </div>
+);

--- a/src/components/Button/ButtonSpinner.tsx
+++ b/src/components/Button/ButtonSpinner.tsx
@@ -4,13 +4,13 @@ import { Spinner } from "../Spinner";
 import "./styles.css";
 
 type ButtonSpinnerProps = {
-  label?: string;
+  hasLabel: boolean;
 };
 
-export const ButtonSpinner: React.FC<ButtonSpinnerProps> = ({ label }) => (
+export const ButtonSpinner: React.FC<ButtonSpinnerProps> = ({ hasLabel }) => (
   <div
     className={`rnf-button-spinner rnf-button-spinner--${
-      label ? "with-label" : "without-label"
+      hasLabel ? "with-label" : "without-label"
     }`}
   >
     <Spinner />

--- a/src/components/Button/index.ts
+++ b/src/components/Button/index.ts
@@ -1,0 +1,2 @@
+export * from "./Button";
+export * from "./ButtonGroup";

--- a/src/components/Button/styles.css
+++ b/src/components/Button/styles.css
@@ -1,0 +1,119 @@
+:root {
+  --rnf-button-padding-x: 8px;
+  --rnf-button-padding-y: 4px;
+  --rnf-button-border-radius: 4px;
+  --rnf-button-font-weight: var(--rnf-font-weight-medium);
+  --rnf-button-font-size: var(--rnf-font-size-sm);
+
+  /* Variant colors */
+  /* Primary */
+  --rnf-button-primary-bg-color: var(--rnf-color-brand-500);
+  --rnf-button-primary-hover-bg-color: var(--rnf-color-brand-700);
+  --rnf-button-primary-border-color: transparent;
+  --rnf-button-primary-text-color: var(--rnf-color-white);
+  /* Secondary */
+  --rnf-button-secondary-bg-color: var(--rnf-color-white);
+  --rnf-button-secondary-hover-bg-color: #dddee1;
+  --rnf-button-secondary-border-color: #dddee1;
+  --rnf-button-secondary-text-color: var(--rnf-color-gray-700);
+}
+
+.rnf-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  user-select: none;
+  white-space: nowrap;
+  vertical-align: middle;
+  width: auto;
+  padding: var(--rnf-button-padding-y) var(--rnf-button-padding-x);
+  border-radius: var(--rnf-button-border-radius);
+  font-size: var(--rnf-button-font-size);
+  line-height: var(--rnf-font-size-lg);
+  font-weight: var(--rnf-button-font-weight);
+  border: 1px solid;
+  appearance: none;
+  cursor: pointer;
+  transition: all 0.1s ease-in-out;
+}
+
+.rnf-button--full-width {
+  width: 100%;
+}
+
+.rnf-button--primary {
+  background-color: var(--rnf-button-primary-bg-color);
+  color: var(--rnf-button-primary-text-color);
+  border-color: var(--rnf-button-primary-border-color);
+}
+
+.rnf-button--primary:hover:not(:disabled),
+.rnf-button--primary:active:not(:disabled) {
+  background-color: var(--rnf-button-primary-hover-bg-color);
+}
+
+.rnf-button:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.rnf-button--secondary {
+  background-color: var(--rnf-button-secondary-bg-color);
+  color: var(--rnf-button-secondary-text-color);
+  border-color: var(--rnf-button-secondary-border-color);
+}
+
+.rnf-button--secondary:hover:not(:disabled),
+.rnf-button--secondary:active:not(:disabled) {
+  background-color: var(--rnf-button-secondary-hover-bg-color);
+}
+
+.rnf-button--dark.rnf-button--secondary {
+  border-color: #43464c;
+  background-color: #43464c;
+  color: var(--rnf-color-white-a-75);
+}
+
+.rnf-button__button-text-hidden {
+  opacity: 0;
+}
+
+.rnf-button--dark.rnf-button--secondary:hover:not(:disabled),
+.rnf-button--dark.rnf-button--secondary:active:not(:disabled) {
+  background-color: var(--rnf-color-gray-600);
+}
+
+/* Button spinner */
+
+.rnf-button-spinner {
+  display: flex;
+  align-items: center;
+  font-size: 1rem;
+  line-height: "normal";
+}
+
+.rnf-button-spinner--without-label {
+  position: absolute;
+}
+
+.rnf-button-spinner--with-label {
+  margin-right: 6px;
+}
+
+.rnf-button--primary .rnf-button-spinner circle {
+  stroke: white;
+}
+
+.rnf-button--secondary .rnf-button-spinner circle {
+  stroke: var(--rnf-button-secondary-text-color);
+}
+
+.rnf-button--dark.rnf-button--secondary .rnf-button-spinner circle {
+  stroke: var(--rnf-color-white-a-75);
+}
+
+/* Button group */
+
+.rnf-button-group > .rnf-button + .rnf-button {
+  margin-left: 8px;
+}

--- a/src/components/NotificationCell/NotificationCell.tsx
+++ b/src/components/NotificationCell/NotificationCell.tsx
@@ -11,6 +11,7 @@ export interface NotificationCellProps {
   item: FeedItem;
   onItemClick?: (item: FeedItem) => void;
   avatar?: ReactNode;
+  children?: ReactNode;
 }
 
 type BlockByName = {
@@ -20,7 +21,7 @@ type BlockByName = {
 export const NotificationCell = React.forwardRef<
   HTMLDivElement,
   NotificationCellProps
->(({ item, onItemClick, avatar }, ref) => {
+>(({ item, onItemClick, avatar, children }, ref) => {
   const { feedClient, colorMode } = useKnockFeed();
 
   const blocksByName: BlockByName = useMemo(() => {
@@ -82,6 +83,12 @@ export const NotificationCell = React.forwardRef<
               className="rnf-notification-cell__content"
               dangerouslySetInnerHTML={{ __html: blocksByName.body.rendered }}
             />
+          )}
+
+          {children && (
+            <div className="rnf-notification-cell__child-content">
+              {children}
+            </div>
           )}
 
           <span className="rnf-notification-cell__timestamp">

--- a/src/components/NotificationCell/styles.css
+++ b/src/components/NotificationCell/styles.css
@@ -152,6 +152,10 @@
   line-height: var(--rnf-font-size-lg);
 }
 
+.rnf-notification-cell__child-content {
+  margin: 0.75em 0 0.5em 0;
+}
+
 /* Archive button */
 
 .rnf-archive-notification-btn {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 import "./theme.css";
-
+export * from "./components/Button";
 export * from "./components/EmptyFeed";
 export * from "./components/Icons";
 export * from "./components/KnockFeedProvider";

--- a/src/stories/Feed.stories.tsx
+++ b/src/stories/Feed.stories.tsx
@@ -1,9 +1,11 @@
 import React, { useRef, useState } from "react";
 import { Story, Meta } from "@storybook/react";
 import {
+  Button,
   KnockFeedProvider,
   NotificationIconButton,
   NotificationFeedPopover,
+  ButtonGroup,
 } from "../";
 
 import "../theme.css";
@@ -85,7 +87,19 @@ const Template: Story<Props> = (args) => {
               key={props.item.id}
               item={props.item}
               avatar={<Avatar name={props.item.actors[0].name} />}
-            />
+            >
+              {props.item.source.key === "new-comment-1" && (
+                <Button
+                  variant="primary"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    window.alert("Approve!");
+                  }}
+                >
+                  Accept
+                </Button>
+              )}
+            </NotificationCell>
           )}
           onNotificationClick={(e) => {
             // Handle the notification click

--- a/src/stories/Feed.stories.tsx
+++ b/src/stories/Feed.stories.tsx
@@ -89,15 +89,26 @@ const Template: Story<Props> = (args) => {
               avatar={<Avatar name={props.item.actors[0].name} />}
             >
               {props.item.source.key === "new-comment-1" && (
-                <Button
-                  variant="primary"
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    window.alert("Approve!");
-                  }}
-                >
-                  Accept
-                </Button>
+                <ButtonGroup>
+                  <Button
+                    variant="primary"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      window.alert("Approve!");
+                    }}
+                  >
+                    Accept
+                  </Button>
+                  <Button
+                    variant="secondary"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      window.alert("Reject!");
+                    }}
+                  >
+                    Reject
+                  </Button>
+                </ButtonGroup>
               )}
             </NotificationCell>
           )}

--- a/src/theme.css
+++ b/src/theme.css
@@ -51,6 +51,9 @@
   --rnf-color-gray-300: #a5acb8;
   --rnf-color-gray-200: #dddee1;
   --rnf-color-gray-100: #e4e8ee;
+  --rnf-color-brand-500: #e95744;
+  --rnf-color-brand-700: #e4321b;
+  --rnf-color-brand-900: #891e10;
 
   /* Component specific colors */
   --rnf-unread-badge-bg-color: #dd514c;


### PR DESCRIPTION
## Description

* Adds new `Button` and `ButtonGroup` components
* `Button` component supports `isLoading` and `loadingText` to handle async actions (modeled after Chakra UI)
* Change the `NotificationCell` to accept `children` so that it can be extended

## Screenshots

![image](https://user-images.githubusercontent.com/822528/145113900-7113f683-9ccd-435d-993d-991707280666.png)
![image](https://user-images.githubusercontent.com/822528/145113937-860b7a7a-82a5-4e12-b27f-0d2cd2d7ce39.png)
![image](https://user-images.githubusercontent.com/822528/145114074-3312e32c-0823-4ba5-ae8b-5c067020059f.png)

## Links

Internal ticket: [KNO-594](https://linear.app/knock/issue/KNO-594/[feed]-add-button-and-buttongroup-components)