### PR TITLE
feat(provider): add rootless mode to provider

### DIFF
--- a/src/components/KnockFeedProvider/KnockFeedContainer.tsx
+++ b/src/components/KnockFeedProvider/KnockFeedContainer.tsx
@@ -1,0 +1,8 @@
+import React from "react";
+import "./styles.css";
+
+export const KnockFeedContainer: React.FC = ({ children }) => {
+  return (
+    <div className="rnf-feed-provider">{children}</div>
+  );
+};

--- a/src/components/KnockFeedProvider/KnockFeedProvider.tsx
+++ b/src/components/KnockFeedProvider/KnockFeedProvider.tsx
@@ -2,8 +2,7 @@ import * as React from "react";
 import Knock, { Feed, FeedStoreState } from "@knocklabs/client";
 import create, { UseStore } from "zustand";
 import { FilterStatus, ColorMode } from "../../constants";
-
-import "./styles.css";
+import { KnockFeedContainer } from "./KnockFeedContainer";
 
 export interface KnockFeedProviderState {
   knock: Knock;
@@ -29,6 +28,7 @@ export interface KnockFeedProviderProps {
   tenant?: string;
   // Extra options
   colorMode?: ColorMode;
+  rootless?: boolean;
 }
 
 export const KnockFeedProvider: React.FC<KnockFeedProviderProps> = ({
@@ -41,6 +41,7 @@ export const KnockFeedProvider: React.FC<KnockFeedProviderProps> = ({
   source,
   tenant,
   colorMode = "light",
+  rootless,
 }) => {
   const [status, setStatus] = React.useState(FilterStatus.All);
 
@@ -79,9 +80,13 @@ export const KnockFeedProvider: React.FC<KnockFeedProviderProps> = ({
     colorMode,
   };
 
+  const content = rootless
+    ? children
+    : <KnockFeedContainer>{children}</KnockFeedContainer>;
+
   return (
     <FeedStateContext.Provider value={state}>
-      <div className="rnf-feed-provider">{children}</div>
+      {content}
     </FeedStateContext.Provider>
   );
 };

--- a/src/components/KnockFeedProvider/index.ts
+++ b/src/components/KnockFeedProvider/index.ts
@@ -1,1 +1,2 @@
 export * from "./KnockFeedProvider";
+export * from "./KnockFeedContainer";


### PR DESCRIPTION
### Changes:
- add `rootless` param to the `KnockFeedProvider` to avoid pollution of the DOM tree when provider is used to wrap whole application
- add `KnockFeedContainer` to wrap existing components in place so that correct styling is applied

### Intent:
Usage of the provider to wrap whole application without affecting DOM structure and styles applied via `.rnf-feed-provider *` selector. This change allows us to have fully custom components which utilize `useKnockFeed` hook with pre-build ones like `UnseenBadge` or `NotificationFeed` wrapped with `KnockFeedContainer`