### PR TITLE
feat: add prop to override archive button, export icon

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ const YourAppLayout = () => {
       userToken={currentUser.knockUserToken}
       // Optionally you can scope the feed in a particular manner
       // tenant={currentWorkspace.id}
+      // Optionally you can make provider to not render any markup and later use KnockFeedContainer to wrap components
+      // rootless
     >
       <NotificationIconButton
         ref={notifButtonRef}

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ const YourAppLayout = () => {
       userToken={currentUser.knockUserToken}
       // Optionally you can scope the feed in a particular manner
       // tenant={currentWorkspace.id}
-      // Optionally you can make provider to not render any markup and later use KnockFeedContainer to wrap components
+      // Optionally you can stop the provider rendering any markup and use `KnockFeedContainer` to wrap components
       // rootless
     >
       <NotificationIconButton

--- a/src/components/Icons/index.ts
+++ b/src/components/Icons/index.ts
@@ -1,3 +1,4 @@
 export { default as BellIcon } from "./Bell";
 export { default as CheckmarkCircle } from "./CheckmarkCircle";
 export { default as ChevronDown } from "./ChevronDown";
+export * from "./CloseCircle";

--- a/src/components/NotificationCell/ArchiveButton.tsx
+++ b/src/components/NotificationCell/ArchiveButton.tsx
@@ -1,7 +1,7 @@
 import { FeedItem } from "@knocklabs/client";
 import React, { MouseEvent, useCallback } from "react";
 import { usePopperTooltip } from "react-popper-tooltip";
-import { CloseCircle } from "../Icons/CloseCircle";
+import { CloseCircle } from "../Icons";
 import { useKnockFeed } from "../KnockFeedProvider";
 
 export interface ArchiveButtonProps {

--- a/src/components/NotificationCell/NotificationCell.tsx
+++ b/src/components/NotificationCell/NotificationCell.tsx
@@ -12,6 +12,7 @@ export interface NotificationCellProps {
   onItemClick?: (item: FeedItem) => void;
   avatar?: ReactNode;
   children?: ReactNode;
+  archiveButton?: ReactNode;
 }
 
 type BlockByName = {
@@ -21,7 +22,7 @@ type BlockByName = {
 export const NotificationCell = React.forwardRef<
   HTMLDivElement,
   NotificationCellProps
->(({ item, onItemClick, avatar, children }, ref) => {
+>(({ item, onItemClick, avatar, children, archiveButton }, ref) => {
   const { feedClient, colorMode } = useKnockFeed();
 
   const blocksByName: BlockByName = useMemo(() => {
@@ -96,7 +97,10 @@ export const NotificationCell = React.forwardRef<
           </span>
         </div>
 
-        <ArchiveButton item={item} />
+        {renderNodeOrFallback(
+          archiveButton,
+          <ArchiveButton item={item} />
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
### Changes:
 - add ability to override `ArchiveButton` for `NotificationCell` via props
 - export `CloseCircle` icon along with other icons
 - update README.md to reflect `rootless` provider option

### Intent:
Existing `NotificationCell` component can be imported and utilized as a standalone component. It may fit perfecly well in terms of design but behavior might need to be changed. For example when `NotificationCell` is used as a toast, archive button can have different behavior such as closing toast notification. Thus it would be great to have this action button overridable.

![image](https://user-images.githubusercontent.com/72133350/149540423-5e1ec15d-9fb7-4e1b-beb5-1ce58af0e01d.png)
