### PR TITLE
feat(popover): add placement prop to customize popover placement

### DIFF
--- a/src/components/NotificationFeedPopover/NotificationFeedPopover.tsx
+++ b/src/components/NotificationFeedPopover/NotificationFeedPopover.tsx
@@ -1,5 +1,6 @@
 import React, { RefObject } from "react";
 import { usePopper } from "react-popper";
+import { Placement } from "@popperjs/core";
 import { NotificationFeed, NotificationFeedProps } from "../NotificationFeed";
 import useComponentVisible from "../../hooks/useComponentVisible";
 
@@ -11,53 +12,54 @@ export interface NotificationFeedPopoverProps extends NotificationFeedProps {
   onClose: (e: Event) => void;
   buttonRef: RefObject<HTMLElement>;
   closeOnClickOutside?: boolean;
+  placement?: Placement;
 }
 
-export const NotificationFeedPopover: React.FC<NotificationFeedPopoverProps> =
-  ({
-    isVisible,
-    onClose,
-    buttonRef,
-    closeOnClickOutside = true,
-    ...feedProps
-  }) => {
-    const { colorMode } = useKnockFeed();
-    const { ref: popperRef } = useComponentVisible(isVisible, onClose, {
-      closeOnClickOutside,
-    });
+export const NotificationFeedPopover: React.FC<NotificationFeedPopoverProps> = ({
+  isVisible,
+  onClose,
+  buttonRef,
+  closeOnClickOutside = true,
+  placement = "bottom-end",
+  ...feedProps
+}) => {
+  const { colorMode } = useKnockFeed();
+  const { ref: popperRef } = useComponentVisible(isVisible, onClose, {
+    closeOnClickOutside,
+  });
 
-    const { styles, attributes } = usePopper(
-      buttonRef.current,
-      popperRef.current,
-      {
-        strategy: "fixed",
-        placement: "bottom-end",
-        modifiers: [
-          {
-            name: "offset",
-            options: {
-              offset: [0, 8],
-            },
+  const { styles, attributes } = usePopper(
+    buttonRef.current,
+    popperRef.current,
+    {
+      strategy: "fixed",
+      placement,
+      modifiers: [
+        {
+          name: "offset",
+          options: {
+            offset: [0, 8],
           },
-        ],
-      }
-    );
+        },
+      ],
+    }
+  );
 
-    return (
-      <div
-        className={`rnf-notification-feed-popover rnf-notification-feed-popover--${colorMode}`}
-        style={{
-          ...styles.popper,
-          visibility: isVisible ? "visible" : "hidden",
-        }}
-        ref={popperRef}
-        {...attributes.popper}
-        role="dialog"
-        tabIndex={-1}
-      >
-        <div className="rnf-notification-feed-popover__inner">
-          <NotificationFeed isVisible={isVisible} {...feedProps} />
-        </div>
+  return (
+    <div
+      className={`rnf-notification-feed-popover rnf-notification-feed-popover--${colorMode}`}
+      style={{
+        ...styles.popper,
+        visibility: isVisible ? "visible" : "hidden",
+      }}
+      ref={popperRef}
+      {...attributes.popper}
+      role="dialog"
+      tabIndex={-1}
+    >
+      <div className="rnf-notification-feed-popover__inner">
+        <NotificationFeed isVisible={isVisible} {...feedProps} />
       </div>
-    );
-  };
+    </div>
+  );
+};


### PR DESCRIPTION
* Adds new `placement` prop to the `NotificationFeedPopover` to customize the placement of the popover (currently defaults to `bottom-end`).

[Internal issue: KNO-1164](https://linear.app/knock/issue/KNO-1164/[feed-sdk]-introduce-positioning-prop)