### PR TITLE
chore: bump @knock/client to 0.5.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "typescript": "^4.2.4"
   },
   "dependencies": {
-    "@knocklabs/client": "^0.5.7",
+    "@knocklabs/client": "^0.5.8",
     "@popperjs/core": "^2.9.2",
     "date-fns": "^2.24.0",
     "lodash.debounce": "^4.0.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1367,10 +1367,10 @@
     "@types/yargs" "^15.0.0"
     chalk "^4.0.0"
 
-"@knocklabs/client@^0.5.7":
-  version "0.5.7"
-  resolved "https://registry.yarnpkg.com/@knocklabs/client/-/client-0.5.7.tgz#4c17167eb97825b7971ae5f3d5db4186cfe08da9"
-  integrity sha512-bbvqPMGh9PVSbcL7wJl7q9GY8rOv/nLQ2H0MsW6RV2sWOMZTsZTSJ8St6ClGFJ0TBBSA78/T3inVlqI+65UYog==
+"@knocklabs/client@^0.5.8":
+  version "0.5.8"
+  resolved "https://registry.yarnpkg.com/@knocklabs/client/-/client-0.5.8.tgz#c50886745c2634d74482281d7dcd33ffa7b88604"
+  integrity sha512-RH17mz5vc9E4sLbFS9OZJvSgjuhi7l1Y5WH1mNDmpKKb5jh56DUZm3b60si/HGIyE6xeGNv7xFVRIeE9UUhAAg==
   dependencies:
     axios "^0.21.4"
     axios-retry "^3.1.9"


### PR DESCRIPTION
Bringing in the new `socket` changes from `@knocklabs/client`