### PR TITLE
fix: add children prop to KnockFeedProvider

### DIFF
--- a/src/components/KnockFeedProvider/KnockFeedProvider.tsx
+++ b/src/components/KnockFeedProvider/KnockFeedProvider.tsx
@@ -23,6 +23,7 @@ export interface KnockFeedProviderProps {
   userToken?: string;
   feedId: string;
   host?: string;
+  children?: React.ReactElement;
   // Feed client scoping options
   source?: string;
   tenant?: string;


### PR DESCRIPTION
When adding children to KnockFeedProvider the following typescript error is shown.

```
 Type '{ children: Element; host: string | undefined; apiKey: string; feedId: string; userId: string; }' is not assignable to type 'IntrinsicAttributes & KnockFeedProviderProps'.
  Property 'children' does not exist on type 'IntrinsicAttributes & KnockFeedProviderProps'.
  ```