### PR TITLE
fix(feeds): ensure websocket connections aren't closed in the feed

### DIFF
--- a/src/components/KnockFeedProvider/KnockFeedProvider.tsx
+++ b/src/components/KnockFeedProvider/KnockFeedProvider.tsx
@@ -32,6 +32,8 @@ export interface KnockFeedProviderProps {
   rootless?: boolean;
 }
 
+type teardownRefCallback = () => void;
+
 export const KnockFeedProvider: React.FC<KnockFeedProviderProps> = ({
   apiKey,
   userId,
@@ -44,29 +46,39 @@ export const KnockFeedProvider: React.FC<KnockFeedProviderProps> = ({
   colorMode = "light",
   rootless,
 }) => {
+  const knockInstance = React.useRef<Knock | null>(null);
+  const feedTeardownRef = React.useRef<teardownRefCallback | null>(null);
   const [status, setStatus] = React.useState(FilterStatus.All);
 
   const knock = React.useMemo(() => {
+    // Cleanup any existing knock instances (if they exist)
+    if (knockInstance.current) {
+      knockInstance.current.teardown();
+    }
+
     const knock = new Knock(apiKey, { host });
     knock.authenticate(userId, userToken);
+    knockInstance.current = knock;
 
     return knock;
   }, [apiKey, host, userId, userToken]);
 
   const [feedClient, useFeedStore] = React.useMemo(() => {
+    // If we have a feed instance already, tear it down
+    if (feedTeardownRef.current) {
+      feedTeardownRef.current();
+    }
+
     const feedClient = knock.feeds.initialize(feedId, {
       source,
       tenant,
     });
     const useFeedStore = create(feedClient.store);
+    const teardown = feedClient.listenForUpdates();
+    feedTeardownRef.current = teardown;
 
     return [feedClient, useFeedStore];
   }, [knock, feedId, source, tenant]);
-
-  React.useEffect(() => {
-    feedClient.listenForUpdates();
-    return () => knock.teardown();
-  }, [feedClient]);
 
   React.useEffect(() => {
     feedClient.fetch({ status });


### PR DESCRIPTION
We have been seeing issues with the [recent changes in React 18](https://reactjs.org/blog/2022/03/08/react-18-upgrade-guide.html#updates-to-strict-mode), where in development React double renders. This had the effect of causing our websocket connection to terminate because of the call to `knock.teardown()` in the `useEffect` hook. 

This change:

1. Connects the feed client to the real-time stream when we're creating the feedClient
2. Moves to using mutable refs to keep track of state for teardowns