### PR TITLE
feat(feed): add support customizing the badge count and open behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ A set of components for integrating a Knock in-app feed into a React application
 **Note: these components are currently designed to be used in conjunction with the Knock in-app feed
 channel, and via React for web only.**
 
+[Full documentation](https://docs.knock.app/in-app-ui/react/overview)
+
 ## Installation
 
 Via NPM:
@@ -52,27 +54,27 @@ const YourAppLayout = () => {
       apiKey={process.env.KNOCK_PUBLIC_API_KEY}
       feedId={process.env.KNOCK_FEED_ID}
       userId={currentUser.id}
-      // Optional in non production environments
-      userToken={currentUser.knockUserToken}
-      // Optionally you can scope the feed in a particular manner
-      // tenant={currentWorkspace.id}
-      // Optionally you can stop the provider rendering any markup and use `KnockFeedContainer` to wrap components
-      // rootless
     >
-      <NotificationIconButton
-        ref={notifButtonRef}
-        onClick={(e) => setIsVisible(!isVisible)}
-      />
-      <NotificationFeedPopover
-        buttonRef={notifButtonRef}
-        isVisible={isVisible}
-        onClose={() => setIsVisible(false)}
-      />
+      <>
+        <NotificationIconButton
+          ref={notifButtonRef}
+          onClick={(e) => setIsVisible(!isVisible)}
+          badgeCountType="unread"
+        />
+        <NotificationFeedPopover
+          buttonRef={notifButtonRef}
+          isVisible={isVisible}
+          onClose={() => setIsVisible(false)}
+          onOpen={({ store, feedClient }) => {
+            const unreadItems = store.items.filter((item) => !item.read_at);
+
+            if (unreadItems.length > 0) {
+              feedClient.markAsRead(unreadItems);
+            }
+          }}
+        />
+      </>
     </KnockFeedProvider>
   );
 };
 ```
-
-## Customizing
-
-See the [documentation](https://docs.knock.app/notification-feeds/customizing-ui) to customize the feed for your application.

--- a/README.md
+++ b/README.md
@@ -59,19 +59,11 @@ const YourAppLayout = () => {
         <NotificationIconButton
           ref={notifButtonRef}
           onClick={(e) => setIsVisible(!isVisible)}
-          badgeCountType="unread"
         />
         <NotificationFeedPopover
           buttonRef={notifButtonRef}
           isVisible={isVisible}
           onClose={() => setIsVisible(false)}
-          onOpen={({ store, feedClient }) => {
-            const unreadItems = store.items.filter((item) => !item.read_at);
-
-            if (unreadItems.length > 0) {
-              feedClient.markAsRead(unreadItems);
-            }
-          }}
         />
       </>
     </KnockFeedProvider>

--- a/src/components/NotificationFeed/NotificationFeed.tsx
+++ b/src/components/NotificationFeed/NotificationFeed.tsx
@@ -11,7 +11,7 @@ import { Spinner } from "../Spinner";
 import { NotificationCell } from "../NotificationCell";
 import { MarkAsRead } from "./MarkAsRead";
 import Dropdown from "./Dropdown";
-import { FilterStatus, FilterStatusToLabel } from "../../constants";
+import { ColorMode, FilterStatus, FilterStatusToLabel } from "../../constants";
 
 import "./styles.css";
 import useOnBottomScroll from "../../hooks/useOnBottomScroll";
@@ -28,11 +28,20 @@ export interface NotificationFeedProps {
   renderItem?: RenderItem;
   onNotificationClick?: OnNotificationClick;
   onMarkAllAsReadClick?: (e: React.MouseEvent, unreadItems: FeedItem[]) => void;
-  isVisible?: boolean;
 }
 
 const defaultRenderItem = (props: RenderItemProps) => (
   <NotificationCell key={props.item.id} {...props} />
+);
+
+const LoadingSpinner = ({ colorMode }: { colorMode: ColorMode }) => (
+  <div className="rnf-notification-feed__spinner-container">
+    <Spinner
+      thickness={3}
+      size="16px"
+      color={colorMode === "dark" ? "rgba(255, 255, 255, 0.65)" : undefined}
+    />
+  </div>
 );
 
 export const NotificationFeed: React.FC<NotificationFeedProps> = ({
@@ -72,16 +81,6 @@ export const NotificationFeed: React.FC<NotificationFeedProps> = ({
     offset: 70,
   });
 
-  const renderSpinner = () => (
-    <div className="rnf-notification-feed__spinner-container">
-      <Spinner
-        thickness={3}
-        size="16px"
-        color={colorMode === "dark" ? "rgba(255, 255, 255, 0.65)" : undefined}
-      />
-    </div>
-  );
-
   return (
     <div
       className={`rnf-notification-feed rnf-notification-feed--${colorMode}`}
@@ -103,7 +102,9 @@ export const NotificationFeed: React.FC<NotificationFeedProps> = ({
       </header>
 
       <div className="rnf-notification-feed__container" ref={containerRef}>
-        {networkStatus === NetworkStatus.loading && renderSpinner()}
+        {networkStatus === NetworkStatus.loading && (
+          <LoadingSpinner colorMode={colorMode} />
+        )}
 
         <div className="rnf-notification-feed__feed-items-container">
           {networkStatus !== NetworkStatus.loading &&
@@ -112,7 +113,9 @@ export const NotificationFeed: React.FC<NotificationFeedProps> = ({
             )}
         </div>
 
-        {networkStatus === NetworkStatus.fetchMore && renderSpinner()}
+        {networkStatus === NetworkStatus.fetchMore && (
+          <LoadingSpinner colorMode={colorMode} />
+        )}
 
         {!requestInFlight && noItems && EmptyComponent}
       </div>

--- a/src/components/NotificationFeed/NotificationFeed.tsx
+++ b/src/components/NotificationFeed/NotificationFeed.tsx
@@ -1,4 +1,9 @@
-import { FeedItem, isRequestInFlight, NetworkStatus } from "@knocklabs/client";
+import {
+  Feed,
+  FeedItem,
+  isRequestInFlight,
+  NetworkStatus,
+} from "@knocklabs/client";
 import React, { ReactNode, useCallback, useEffect, useRef } from "react";
 import { EmptyFeed } from "../EmptyFeed";
 import { useKnockFeed } from "../KnockFeedProvider";
@@ -23,7 +28,7 @@ export interface NotificationFeedProps {
   renderItem?: RenderItem;
   onNotificationClick?: OnNotificationClick;
   onMarkAllAsReadClick?: (e: React.MouseEvent, unreadItems: FeedItem[]) => void;
-  isVisible: boolean;
+  isVisible?: boolean;
 }
 
 const defaultRenderItem = (props: RenderItemProps) => (
@@ -35,7 +40,6 @@ export const NotificationFeed: React.FC<NotificationFeedProps> = ({
   renderItem = defaultRenderItem,
   onNotificationClick,
   onMarkAllAsReadClick,
-  isVisible = false,
 }) => {
   const {
     status,
@@ -48,9 +52,6 @@ export const NotificationFeed: React.FC<NotificationFeedProps> = ({
   const pageInfo = useFeedStore((state) => state.pageInfo);
   const items = useFeedStore((state) => state.items);
   const networkStatus = useFeedStore((state) => state.networkStatus);
-  const unseenItems = useFeedStore((state) =>
-    state.items.filter((item) => !item.seen_at)
-  );
 
   const containerRef = useRef<HTMLDivElement>(null);
   const noItems = items.length === 0;
@@ -70,12 +71,6 @@ export const NotificationFeed: React.FC<NotificationFeedProps> = ({
     callback: onBottomCallback,
     offset: 70,
   });
-
-  useEffect(() => {
-    if (isVisible && unseenItems.length > 0) {
-      feedClient.markAsSeen(unseenItems);
-    }
-  }, [isVisible]);
 
   const renderSpinner = () => (
     <div className="rnf-notification-feed__spinner-container">

--- a/src/components/NotificationFeedPopover/NotificationFeedPopover.tsx
+++ b/src/components/NotificationFeedPopover/NotificationFeedPopover.tsx
@@ -1,4 +1,4 @@
-import React, { RefObject } from "react";
+import React, { RefObject, useEffect } from "react";
 import { usePopper } from "react-popper";
 import { Placement } from "@popperjs/core";
 import { NotificationFeed, NotificationFeedProps } from "../NotificationFeed";
@@ -6,9 +6,25 @@ import useComponentVisible from "../../hooks/useComponentVisible";
 
 import "./styles.css";
 import { useKnockFeed } from "../KnockFeedProvider";
+import { Feed, FeedStoreState } from "@knocklabs/client";
+
+type OnOpenOptions = {
+  store: FeedStoreState;
+  feedClient: Feed;
+};
+
+const defaultOnOpen = ({ store, feedClient }: OnOpenOptions) => {
+  // Find all of the unseen items only
+  const unseenItems = store.items.filter((item) => !item.seen_at);
+
+  if (unseenItems.length > 0) {
+    feedClient.markAsSeen(unseenItems);
+  }
+};
 
 export interface NotificationFeedPopoverProps extends NotificationFeedProps {
   isVisible: boolean;
+  onOpen?: (arg: OnOpenOptions) => void;
   onClose: (e: Event) => void;
   buttonRef: RefObject<HTMLElement>;
   closeOnClickOutside?: boolean;
@@ -17,13 +33,16 @@ export interface NotificationFeedPopoverProps extends NotificationFeedProps {
 
 export const NotificationFeedPopover: React.FC<NotificationFeedPopoverProps> = ({
   isVisible,
+  onOpen = defaultOnOpen,
   onClose,
   buttonRef,
   closeOnClickOutside = true,
   placement = "bottom-end",
   ...feedProps
 }) => {
-  const { colorMode } = useKnockFeed();
+  const { colorMode, feedClient, useFeedStore } = useKnockFeed();
+  const store = useFeedStore();
+
   const { ref: popperRef } = useComponentVisible(isVisible, onClose, {
     closeOnClickOutside,
   });
@@ -44,6 +63,14 @@ export const NotificationFeedPopover: React.FC<NotificationFeedPopoverProps> = (
       ],
     }
   );
+
+  useEffect(() => {
+    // Whenever the feed is opened, we want to invoke the `onOpen` callback
+    // function to handle any side effects.
+    if (isVisible && onOpen) {
+      onOpen({ store, feedClient });
+    }
+  }, [isVisible]);
 
   return (
     <div

--- a/src/components/NotificationFeedPopover/NotificationFeedPopover.tsx
+++ b/src/components/NotificationFeedPopover/NotificationFeedPopover.tsx
@@ -85,7 +85,7 @@ export const NotificationFeedPopover: React.FC<NotificationFeedPopoverProps> = (
       tabIndex={-1}
     >
       <div className="rnf-notification-feed-popover__inner">
-        <NotificationFeed isVisible={isVisible} {...feedProps} />
+        <NotificationFeed {...feedProps} />
       </div>
     </div>
   );

--- a/src/components/NotificationIconButton/NotificationIconButton.tsx
+++ b/src/components/NotificationIconButton/NotificationIconButton.tsx
@@ -1,18 +1,20 @@
 import React, { SyntheticEvent } from "react";
 import { BellIcon } from "../Icons";
 import { useKnockFeed } from "../KnockFeedProvider";
-import { UnseenBadge } from "../UnseenBadge";
+import { BadgeCountType, UnseenBadge } from "../UnseenBadge";
 
 import "./styles.css";
 
 export interface NotificationIconButtonProps {
+  // What value should we use to drive the badge count?
+  badgeCountType?: BadgeCountType;
   onClick: (e: SyntheticEvent) => void;
 }
 
 export const NotificationIconButton = React.forwardRef<
   HTMLButtonElement,
   NotificationIconButtonProps
->(({ onClick }, ref) => {
+>(({ onClick, badgeCountType }, ref) => {
   const { colorMode } = useKnockFeed();
 
   return (
@@ -22,7 +24,7 @@ export const NotificationIconButton = React.forwardRef<
       onClick={onClick}
     >
       <BellIcon />
-      <UnseenBadge />
+      <UnseenBadge badgeCountType={badgeCountType} />
     </button>
   );
 });

--- a/src/components/UnseenBadge/UnseenBadge.tsx
+++ b/src/components/UnseenBadge/UnseenBadge.tsx
@@ -11,8 +11,11 @@ export type UnseenBadgeProps = {
   badgeCountType?: BadgeCountType;
 };
 
-function selectBadgeCount(badgeCount: BadgeCountType, metadata: FeedMetadata) {
-  switch (badgeCount) {
+function selectBadgeCount(
+  badgeCountType: BadgeCountType,
+  metadata: FeedMetadata
+) {
+  switch (badgeCountType) {
     case "all":
       return metadata.total_count;
     case "unread":

--- a/src/components/UnseenBadge/UnseenBadge.tsx
+++ b/src/components/UnseenBadge/UnseenBadge.tsx
@@ -3,15 +3,37 @@ import { useKnockFeed } from "../KnockFeedProvider";
 import { formatBadgeCount } from "../../utils";
 
 import "./styles.css";
+import { FeedMetadata } from "@knocklabs/client";
 
-export const UnseenBadge = () => {
+export type BadgeCountType = "unseen" | "unread" | "all";
+
+export type UnseenBadgeProps = {
+  badgeCountType?: BadgeCountType;
+};
+
+function selectBadgeCount(badgeCount: BadgeCountType, metadata: FeedMetadata) {
+  switch (badgeCount) {
+    case "all":
+      return metadata.total_count;
+    case "unread":
+      return metadata.unread_count;
+    case "unseen":
+      return metadata.unseen_count;
+  }
+}
+
+export const UnseenBadge: React.FC<UnseenBadgeProps> = ({
+  badgeCountType = "unseen",
+}) => {
   const { useFeedStore } = useKnockFeed();
-  const unseenCount = useFeedStore((state) => state.metadata.unseen_count);
+  const badgeCountValue = useFeedStore((state) =>
+    selectBadgeCount(badgeCountType, state.metadata)
+  );
 
-  return unseenCount !== 0 ? (
+  return badgeCountValue !== 0 ? (
     <div className="rnf-unseen-badge">
       <span className="rnf-unseen-badge__count">
-        {formatBadgeCount(unseenCount)}
+        {formatBadgeCount(badgeCountValue)}
       </span>
     </div>
   ) : null;


### PR DESCRIPTION
This PR adds support for 2 new options:

`badgeCountType` on the `NotificationIconButton` and `UnseenBadge`: allows the behavior of what count is displayed on the badge to be customized. The supported options are `"unseen" | "unread" | "all"`. 

`onOpen` on the `NotificationFeedPopover`: allows a custom function to be passed that will be invoked each time the feed is opened. This defaults to the existing behavior of marking all unseen items as "seen" but the behavior can now be customized so that items can be marked as read, or archived once a feed is shown.

**Note**: we previously changed the visibility on the `NotificationFeed`, but this actually made no sense as the `NotificationFeed` never needed to know about visibility beyond changing the status. I moved the behavior to the `NotificationFeedPopover` as the popover itself needs to understand the visible state.

Welcome to feedback!

[Internal task](https://linear.app/knock/issue/KNO-1479/[in-app-feed]-add-ability-to-customize-readseen-behavior)