### PR TITLE
fix: correctly handle feed property switching

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@knocklabs/react-notification-feed",
-  "version": "0.6.0",
+  "version": "0.6.1-rc.1",
   "description": "A set of React components to render feeds powered by Knock",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
@@ -80,7 +80,7 @@
     "typescript": "^4.2.4"
   },
   "dependencies": {
-    "@knocklabs/client": "^0.5.9",
+    "@knocklabs/client": "^0.6.0-rc.1",
     "@popperjs/core": "^2.9.2",
     "date-fns": "^2.24.0",
     "lodash.debounce": "^4.0.8",

--- a/src/components/NotificationFeed/NotificationFeed.tsx
+++ b/src/components/NotificationFeed/NotificationFeed.tsx
@@ -4,7 +4,13 @@ import {
   isRequestInFlight,
   NetworkStatus,
 } from "@knocklabs/client";
-import React, { ReactNode, useCallback, useEffect, useRef } from "react";
+import React, {
+  ReactNode,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
 import { EmptyFeed } from "../EmptyFeed";
 import { useKnockFeed } from "../KnockFeedProvider";
 import { Spinner } from "../Spinner";
@@ -50,19 +56,16 @@ export const NotificationFeed: React.FC<NotificationFeedProps> = ({
   onNotificationClick,
   onMarkAllAsReadClick,
 }) => {
-  const {
-    status,
-    setStatus,
-    feedClient,
-    useFeedStore,
-    colorMode,
-  } = useKnockFeed();
+  const [status, setStatus] = useState(FilterStatus.All);
+  const { feedClient, useFeedStore, colorMode } = useKnockFeed();
 
-  const pageInfo = useFeedStore((state) => state.pageInfo);
-  const items = useFeedStore((state) => state.items);
-  const networkStatus = useFeedStore((state) => state.networkStatus);
-
+  const { pageInfo, items, networkStatus } = useFeedStore();
   const containerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    feedClient.fetch({ status });
+  }, [status]);
+
   const noItems = items.length === 0;
   const requestInFlight = isRequestInFlight(networkStatus);
 

--- a/src/hooks/useAuthenticatedKnockClient.ts
+++ b/src/hooks/useAuthenticatedKnockClient.ts
@@ -1,0 +1,23 @@
+import React, { useMemo } from "react";
+import Knock, { KnockOptions } from "@knocklabs/client";
+
+function useAuthenticatedKnockClient(
+  apiKey: string,
+  userId: string,
+  userToken: string | undefined,
+  options: KnockOptions = {}
+) {
+  const knockRef = React.useRef<Knock | null>();
+
+  return useMemo(() => {
+    if (knockRef.current) knockRef.current.teardown();
+
+    const knock = new Knock(apiKey, options);
+    knock.authenticate(userId, userToken);
+    knockRef.current = knock;
+
+    return knock;
+  }, [apiKey, userId, userToken]);
+}
+
+export default useAuthenticatedKnockClient;

--- a/src/hooks/useFeedClient.ts
+++ b/src/hooks/useFeedClient.ts
@@ -1,0 +1,21 @@
+import Knock, { Feed, FeedClientOptions } from "@knocklabs/client";
+import { useMemo, useRef } from "react";
+
+function useFeedClient(
+  knock: Knock,
+  feedId: string,
+  options: FeedClientOptions = {}
+) {
+  const feedClientRef = useRef<Feed | null>();
+
+  return useMemo(() => {
+    if (feedClientRef.current) feedClientRef.current.teardown();
+
+    const feedClient = knock.feeds.initialize(feedId, options);
+    feedClient.listenForUpdates();
+
+    return feedClient;
+  }, [knock, feedId, options.source, options.tenant]);
+}
+
+export default useFeedClient;

--- a/src/stories/Feed.stories.tsx
+++ b/src/stories/Feed.stories.tsx
@@ -86,7 +86,7 @@ const Template: Story<Props> = (args) => {
             <NotificationCell
               key={props.item.id}
               item={props.item}
-              avatar={<Avatar name={props.item.actors[0].name} />}
+              avatar={<Avatar name={props.item.actors[0]?.name ?? ""} />}
             >
               {props.item.source.key === "new-comment-1" && (
                 <ButtonGroup>

--- a/yarn.lock
+++ b/yarn.lock
@@ -1367,10 +1367,10 @@
     "@types/yargs" "^15.0.0"
     chalk "^4.0.0"
 
-"@knocklabs/client@^0.5.9":
-  version "0.5.9"
-  resolved "https://registry.yarnpkg.com/@knocklabs/client/-/client-0.5.9.tgz#801b568a8773c77214854acbd7ac165215e8a37b"
-  integrity sha512-Ac6QdMrb4bpqvSjKbZi2BNUtJoQo4hz4CnkIfwHx9igzMMw0LX0JUoko1w7LmSPW3qKZazb+xmhld+o11oqQ5w==
+"@knocklabs/client@^0.6.0-rc.1":
+  version "0.6.0-rc.1"
+  resolved "https://registry.yarnpkg.com/@knocklabs/client/-/client-0.6.0-rc.1.tgz#251435de53c09421495980d5e768d8d4d8ce97cd"
+  integrity sha512-EabDAP/ld3+z9fUB7+YMnMTXWGojfIsDrvX2ielcuVisAVwO58E/ahza+CkfkV3MwGJn41W2N5+Bd9fLG/vroQ==
   dependencies:
     axios "^0.21.4"
     axios-retry "^3.1.9"


### PR DESCRIPTION
This PR is intended to fix the issues relating to switching tenant / source properties and not having the feed properly re-render. It depends on https://github.com/knocklabs/knock-client-js/pull/10.

* Refactored knock client setup into a new `useAuthenticatedKnockClient` hook that handles teardown
* Refactored feed setup into a new `useFeedClient` hook that handles teardown
* Removed `status` and `setStatus` from the `KnockFeedProvider` and put inside of the `NotificationFeed`

[Internal Knock ticket](https://linear.app/knock/issue/KNO-1595/[in-app-feed]-issue-with-switching-tenants)