### PR TITLE
feat(feed): introduce powered by knock branding

### DIFF
--- a/src/components/EmptyFeed/EmptyFeed.tsx
+++ b/src/components/EmptyFeed/EmptyFeed.tsx
@@ -2,13 +2,7 @@ import React from "react";
 import { useKnockFeed } from "../KnockFeedProvider";
 import "./styles.css";
 
-export type EmptyFeedProps = {
-  showPoweredBy?: boolean;
-};
-
-export const EmptyFeed: React.FC<EmptyFeedProps> = ({
-  showPoweredBy = true,
-}) => {
+export const EmptyFeed: React.FC = () => {
   const { colorMode } = useKnockFeed();
 
   return (
@@ -19,16 +13,6 @@ export const EmptyFeed: React.FC<EmptyFeedProps> = ({
           We'll let you know when we've got something new for you.
         </p>
       </div>
-
-      {showPoweredBy && (
-        <a
-          href="https://knock.app?utm_source=in-app-feed&utm_medium=in-app-feed&utm_campaign=in-app-feed"
-          target="_blank"
-          className="rnf-empty-feed__powered-by-knock"
-        >
-          Powered by Knock
-        </a>
-      )}
     </div>
   );
 };

--- a/src/components/EmptyFeed/styles.css
+++ b/src/components/EmptyFeed/styles.css
@@ -32,15 +32,6 @@
   margin: 0;
 }
 
-.rnf-empty-feed__powered-by-knock {
-  font-size: var(--rnf-font-size-xs);
-  font-weight: var(--rnf-font-weight-medium);
-  color: var(--rnf-color-gray-200);
-  text-decoration: none;
-  position: absolute;
-  bottom: var(--rnf-spacing-2);
-}
-
 /* Themes */
 
 .rnf-empty-feed--dark .rnf-empty-feed__header {
@@ -49,8 +40,4 @@
 
 .rnf-empty-feed--dark .rnf-empty-feed__body {
   color: var(--rnf-color-gray-400);
-}
-
-.rnf-empty-feed--dark .rnf-empty-feed__powered-by-knock {
-  color: var(--rnf-color-gray-500);
 }

--- a/src/components/NotificationFeed/NotificationFeed.tsx
+++ b/src/components/NotificationFeed/NotificationFeed.tsx
@@ -16,6 +16,7 @@ import { ColorMode, FilterStatus, FilterStatusToLabel } from "../../constants";
 
 import "./styles.css";
 import useOnBottomScroll from "../../hooks/useOnBottomScroll";
+import useFeedSettings from "../../hooks/useFeedSettings";
 
 export type OnNotificationClick = (item: FeedItem) => void;
 export type RenderItem = ({ item }: RenderItemProps) => ReactNode;
@@ -52,6 +53,9 @@ const OrderedFilterStatuses = [
   FilterStatus.Read,
 ];
 
+const poweredByKnockUrl =
+  "https://knock.app?utm_source=in-app-feed&utm_medium=in-app&utm_campaign=in-app-branding";
+
 export const NotificationFeed: React.FC<NotificationFeedProps> = ({
   EmptyComponent = <EmptyFeed />,
   renderItem = defaultRenderItem,
@@ -61,6 +65,7 @@ export const NotificationFeed: React.FC<NotificationFeedProps> = ({
 }) => {
   const [status, setStatus] = useState(initialFilterStatus);
   const { feedClient, useFeedStore, colorMode } = useKnockFeed();
+  const { settings } = useFeedSettings(feedClient);
 
   const { pageInfo, items, networkStatus } = useFeedStore();
   const containerRef = useRef<HTMLDivElement>(null);
@@ -128,6 +133,14 @@ export const NotificationFeed: React.FC<NotificationFeedProps> = ({
 
         {!requestInFlight && noItems && EmptyComponent}
       </div>
+
+      {settings?.features.branding_required && (
+        <div className="rnf-notification-feed__knock-branding">
+          <a href={poweredByKnockUrl} target="_blank">
+            Powered by Knock
+          </a>
+        </div>
+      )}
     </div>
   );
 };

--- a/src/components/NotificationFeed/styles.css
+++ b/src/components/NotificationFeed/styles.css
@@ -6,6 +6,8 @@
 .rnf-notification-feed {
   background-color: var(--rnf-color-white);
   height: 100%;
+  display: flex;
+  flex-direction: column;
 }
 
 /* Dropdown */
@@ -83,8 +85,8 @@
 }
 
 .rnf-notification-feed__container {
-  height: calc(100% - var(--rnf-notification-feed-header-height));
   overflow-y: auto;
+  flex: 1;
 }
 
 .rnf-notification-feed__spinner-container {
@@ -94,6 +96,24 @@
 .rnf-notification-feed__spinner-container svg {
   margin: 0 auto;
   display: block;
+}
+
+/* Knock branding */
+
+.rnf-notification-feed__knock-branding {
+  text-align: center;
+}
+
+.rnf-notification-feed__knock-branding a {
+  display: block;
+  font-size: var(--rnf-font-size-sm);
+  color: var(--rnf-color-gray-500);
+  padding: 6px;
+  border-top: 1px solid var(--rnf-color-gray-100);
+}
+
+.rnf-notification-feed__knock-branding a:hover {
+  background-color: #f1f6fc;
 }
 
 /* Themes */
@@ -112,4 +132,13 @@
 
 .rnf-mark-all-as-read--dark:disabled {
   color: var(--rnf-color-gray-500);
+}
+
+.rnf-notification-feed--dark .rnf-notification-feed__knock-branding a {
+  color: var(--rnf-color-gray-400);
+  border-top-color: rgba(105, 115, 134, 0.65);
+}
+
+.rnf-notification-feed--dark .rnf-notification-feed__knock-branding a:hover {
+  background-color: #393b40;
 }

--- a/src/hooks/useFeedSettings.ts
+++ b/src/hooks/useFeedSettings.ts
@@ -1,0 +1,43 @@
+import { Feed } from "@knocklabs/client";
+import { useEffect, useState } from "react";
+
+export type FeedSettings = {
+  features: {
+    branding_required: boolean;
+  };
+};
+
+function useFeedSettings(
+  feedClient: Feed
+): { settings: FeedSettings | null; loading: boolean } {
+  const [settings, setSettings] = useState(null);
+  const [isLoading, setIsLoading] = useState(false);
+
+  // TODO: consider moving this into the feed client and into the feed store state when
+  // we're using this in other areas of the feed
+  useEffect(() => {
+    async function getSettings() {
+      const knock = feedClient.knock;
+      const apiClient = knock.client();
+      const feedSettingsPath = `/v1/users/${knock.userId}/feeds/${feedClient.feedId}/settings`;
+      setIsLoading(true);
+
+      const response = await apiClient.makeRequest({
+        method: "GET",
+        url: feedSettingsPath,
+      });
+
+      if (!response.error) {
+        setSettings(response.body);
+      }
+
+      setIsLoading(false);
+    }
+
+    getSettings();
+  }, []);
+
+  return { settings, loading: isLoading };
+}
+
+export default useFeedSettings;


### PR DESCRIPTION
Adds new powered by Knock branding to the bottom of the feed, with support in light and dark modes. Uses the new `/v1/users/:id/feed/:id/settings` endpoint to retrieve settings to determine if we should render the branding or not via a new `useFeedSettings` hook.

Note: also removed the `powered by Knock` branding on the empty state.