### PR TITLE
chore(kno-2198): bump @knocklabs/client version to access 'has_tenant' feed query opt

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "typescript": "^4.2.4"
   },
   "dependencies": {
-    "@knocklabs/client": "^0.7.0",
+    "@knocklabs/client": "^0.8.2",
     "@popperjs/core": "^2.9.2",
     "date-fns": "^2.24.0",
     "lodash.debounce": "^4.0.8",

--- a/src/hooks/useNotifications.ts
+++ b/src/hooks/useNotifications.ts
@@ -17,7 +17,7 @@ function useNotifications(
     feedClientRef.current = feedClient;
 
     return feedClient;
-  }, [knock, feedId, options.source, options.tenant]);
+  }, [knock, feedId, options.source, options.tenant, options.has_tenant, options.archived]);
 }
 
 export default useNotifications;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -32,7 +32,7 @@ export function feedProviderKey(
   userFeedId: string,
   options: FeedClientOptions = {}
 ) {
-  return [userFeedId, options.source, options.tenant, options.archived]
-    .filter((f) => !!f)
+  return [userFeedId, options.source, options.tenant, options.has_tenant, options.archived]
+    .filter((f) => f !== null && f !== undefined)
     .join("-");
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1367,10 +1367,10 @@
     "@types/yargs" "^15.0.0"
     chalk "^4.0.0"
 
-"@knocklabs/client@^0.7.0":
-  version "0.7.0"
-  resolved "https://registry.yarnpkg.com/@knocklabs/client/-/client-0.7.0.tgz#281fde79fda35902cde8fc85558f01f9b0b47874"
-  integrity sha512-J2cdPrrkYrJdVk2C7HMFRWt4zeVhKReLzbzH16myIx82LyqrgRGUc5D+JoEy/Gi6Zg9BahzuwYXfJf4nfFR9pA==
+"@knocklabs/client@^0.8.2":
+  version "0.8.2"
+  resolved "https://registry.yarnpkg.com/@knocklabs/client/-/client-0.8.2.tgz#8264bde385e0cf2f769c89bf1775ee0485d844d0"
+  integrity sha512-AdxTyvQiMzUn0xUQ9GxrMRH9zFT2W9AbWj2QIun/WCNb39kRhxnYqqBaQNs/z1xk9Torbgrj7fEPzgDWPUJLqA==
   dependencies:
     axios "^0.21.4"
     axios-retry "^3.1.9"


### PR DESCRIPTION
- Ensures that when devs update this package they'll be able to pass the `has_tenant` filter into the provider component
- Updates `feedProviderKey` to use has_tenant option when generating key
- Updates `useNotification` hook to observe `has_tenant` and `archived` options in its memo wrapper of feed init. We should reinit the feed when these params change so that a freshly scoped socket connection is established.