### PR TITLE
feat: add translations support for the notification feed

### DIFF
--- a/src/components/EmptyFeed/EmptyFeed.tsx
+++ b/src/components/EmptyFeed/EmptyFeed.tsx
@@ -1,17 +1,17 @@
 import React from "react";
+import { useTranslations } from "../../hooks/useTranslations";
 import { useKnockFeed } from "../KnockFeedProvider";
 import "./styles.css";
 
 export const EmptyFeed: React.FC = () => {
   const { colorMode } = useKnockFeed();
+  const { t } = useTranslations();
 
   return (
     <div className={`rnf-empty-feed rnf-empty-feed--${colorMode}`}>
       <div className="rnf-empty-feed__inner">
-        <h2 className="rnf-empty-feed__header">No notifications yet</h2>
-        <p className="rnf-empty-feed__body">
-          We'll let you know when we've got something new for you.
-        </p>
+        <h2 className="rnf-empty-feed__header">{t("emptyFeedTitle")}</h2>
+        <p className="rnf-empty-feed__body">{t("emptyFeedBody")}</p>
       </div>
     </div>
   );

--- a/src/components/KnockFeedProvider/KnockFeedProvider.tsx
+++ b/src/components/KnockFeedProvider/KnockFeedProvider.tsx
@@ -11,7 +11,7 @@ import { useAuthenticatedKnockClient, useNotifications } from "../../hooks";
 import { feedProviderKey } from "../../utils";
 import { KnockFeedContainer } from "./KnockFeedContainer";
 import { KnockI18nProvider } from "../KnockI18nProvider";
-import { Translation } from "../../i18n";
+import { I18nContent } from "../../i18n";
 
 export interface KnockFeedProviderState {
   knock: Knock;
@@ -43,7 +43,7 @@ export interface KnockFeedProviderProps {
   defaultFeedOptions?: FeedClientOptions;
 
   // i18n translations
-  i18n?: Translation;
+  i18n?: I18nContent;
 }
 
 export const KnockFeedProvider: React.FC<KnockFeedProviderProps> = ({

--- a/src/components/KnockFeedProvider/KnockFeedProvider.tsx
+++ b/src/components/KnockFeedProvider/KnockFeedProvider.tsx
@@ -10,6 +10,8 @@ import { ColorMode } from "../../constants";
 import { useAuthenticatedKnockClient, useNotifications } from "../../hooks";
 import { feedProviderKey } from "../../utils";
 import { KnockFeedContainer } from "./KnockFeedContainer";
+import { KnockI18nProvider } from "../KnockI18nProvider";
+import { Translation } from "../../i18n";
 
 export interface KnockFeedProviderState {
   knock: Knock;
@@ -39,6 +41,9 @@ export interface KnockFeedProviderProps {
 
   // Feed client options
   defaultFeedOptions?: FeedClientOptions;
+
+  // i18n translations
+  i18n?: Translation;
 }
 
 export const KnockFeedProvider: React.FC<KnockFeedProviderProps> = ({
@@ -51,6 +56,7 @@ export const KnockFeedProvider: React.FC<KnockFeedProviderProps> = ({
   defaultFeedOptions = {},
   colorMode = "light",
   rootless = false,
+  i18n,
 }) => {
   const knock = useAuthenticatedKnockClient(apiKey, userId, userToken, {
     host,
@@ -75,7 +81,7 @@ export const KnockFeedProvider: React.FC<KnockFeedProviderProps> = ({
         colorMode,
       }}
     >
-      {content}
+      <KnockI18nProvider i18n={i18n}>{content}</KnockI18nProvider>
     </FeedStateContext.Provider>
   );
 };

--- a/src/components/KnockI18nProvider/KnockI18nProvider.tsx
+++ b/src/components/KnockI18nProvider/KnockI18nProvider.tsx
@@ -1,0 +1,21 @@
+import React from "react";
+import { i18n as translations, Translation } from "../../i18n";
+
+export const I18nContext = React.createContext<Translation>(translations.en);
+
+interface KnockI18nProviderProps {
+  i18n?: Translation;
+  children: JSX.Element | undefined;
+}
+
+export function KnockI18nProvider({ i18n, ...props }: KnockI18nProviderProps) {
+  const translationEntry = React.useMemo<Translation>(() => {
+    if (typeof i18n === "undefined") {
+      return translations.en;
+    }
+
+    return i18n;
+  }, [i18n]);
+
+  return <I18nContext.Provider {...props} value={translationEntry} />;
+}

--- a/src/components/KnockI18nProvider/KnockI18nProvider.tsx
+++ b/src/components/KnockI18nProvider/KnockI18nProvider.tsx
@@ -1,21 +1,16 @@
 import React from "react";
-import { i18n as translations, Translation } from "../../i18n";
+import { locales, I18nContent } from "../../i18n";
 
-export const I18nContext = React.createContext<Translation>(translations.en);
+export const I18nContext = React.createContext<I18nContent>(locales.en);
 
 interface KnockI18nProviderProps {
-  i18n?: Translation;
+  i18n?: I18nContent;
   children: JSX.Element | undefined;
 }
 
-export function KnockI18nProvider({ i18n, ...props }: KnockI18nProviderProps) {
-  const translationEntry = React.useMemo<Translation>(() => {
-    if (typeof i18n === "undefined") {
-      return translations.en;
-    }
-
-    return i18n;
-  }, [i18n]);
-
-  return <I18nContext.Provider {...props} value={translationEntry} />;
+export function KnockI18nProvider({
+  i18n = locales.en,
+  ...props
+}: KnockI18nProviderProps) {
+  return <I18nContext.Provider {...props} value={i18n} />;
 }

--- a/src/components/KnockI18nProvider/index.ts
+++ b/src/components/KnockI18nProvider/index.ts
@@ -1,0 +1,1 @@
+export * from "./KnockI18nProvider";

--- a/src/components/NotificationCell/ArchiveButton.tsx
+++ b/src/components/NotificationCell/ArchiveButton.tsx
@@ -1,6 +1,7 @@
 import { FeedItem } from "@knocklabs/client";
 import React, { MouseEvent, useCallback } from "react";
 import { usePopperTooltip } from "react-popper-tooltip";
+import { useTranslations } from "../../hooks/useTranslations";
 import { CloseCircle } from "../Icons";
 import { useKnockFeed } from "../KnockFeedProvider";
 
@@ -10,6 +11,7 @@ export interface ArchiveButtonProps {
 
 const ArchiveButton: React.FC<ArchiveButtonProps> = ({ item }) => {
   const { colorMode, feedClient } = useKnockFeed();
+  const { t } = useTranslations();
 
   const onClick = useCallback(
     (e: MouseEvent<HTMLButtonElement>) => {
@@ -43,7 +45,7 @@ const ArchiveButton: React.FC<ArchiveButtonProps> = ({ item }) => {
             className: `rnf-tooltip rnf-tooltip--${colorMode}`,
           })}
         >
-          Archive this notification
+          {t("archiveNotification")}
         </div>
       )}
     </button>

--- a/src/components/NotificationCell/NotificationCell.tsx
+++ b/src/components/NotificationCell/NotificationCell.tsx
@@ -6,6 +6,7 @@ import { useKnockFeed } from "../KnockFeedProvider";
 import { formatTimestamp, renderNodeOrFallback } from "../../utils";
 
 import "./styles.css";
+import { useTranslations } from "../../hooks/useTranslations";
 
 export interface NotificationCellProps {
   item: FeedItem;
@@ -24,6 +25,7 @@ export const NotificationCell = React.forwardRef<
   NotificationCellProps
 >(({ item, onItemClick, avatar, children, archiveButton }, ref) => {
   const { feedClient, colorMode } = useKnockFeed();
+  const { dateFnsLocale } = useTranslations();
 
   const blocksByName: BlockByName = useMemo(() => {
     return item.blocks.reduce((acc, block) => {
@@ -75,7 +77,7 @@ export const NotificationCell = React.forwardRef<
 
         {renderNodeOrFallback(
           avatar,
-          actor && ("name" in actor) && actor.name && (
+          actor && "name" in actor && actor.name && (
             <Avatar name={actor.name} src={actor.avatar} />
           )
         )}
@@ -95,7 +97,7 @@ export const NotificationCell = React.forwardRef<
           )}
 
           <span className="rnf-notification-cell__timestamp">
-            {formatTimestamp(item.inserted_at)}
+            {formatTimestamp(item.inserted_at, { locale: dateFnsLocale() })}
           </span>
         </div>
 

--- a/src/components/NotificationFeed/MarkAsRead.tsx
+++ b/src/components/NotificationFeed/MarkAsRead.tsx
@@ -2,6 +2,7 @@ import * as React from "react";
 import { FeedItem } from "@knocklabs/client";
 import { useKnockFeed } from "../KnockFeedProvider";
 import { CheckmarkCircle } from "../Icons";
+import { useTranslations } from "../../hooks/useTranslations";
 
 import "./styles.css";
 
@@ -11,6 +12,7 @@ export type MarkAsReadProps = {
 
 export const MarkAsRead: React.FC<MarkAsReadProps> = ({ onClick }) => {
   const { useFeedStore, feedClient, colorMode } = useKnockFeed();
+  const { t } = useTranslations();
 
   const unreadItems = useFeedStore((state) =>
     state.items.filter((item) => !item.read_at)
@@ -32,7 +34,7 @@ export const MarkAsRead: React.FC<MarkAsReadProps> = ({ onClick }) => {
       disabled={unreadCount === 0}
       onClick={onClickHandler}
     >
-      Mark all as read
+      {t("markAllAsRead")}
       <CheckmarkCircle />
     </button>
   );

--- a/src/components/NotificationFeed/NotificationFeed.tsx
+++ b/src/components/NotificationFeed/NotificationFeed.tsx
@@ -12,7 +12,7 @@ import { Spinner } from "../Spinner";
 import { NotificationCell } from "../NotificationCell";
 import { MarkAsRead } from "./MarkAsRead";
 import Dropdown from "./Dropdown";
-import { ColorMode, FilterStatus, FilterStatusToLabel } from "../../constants";
+import { ColorMode, FilterStatus } from "../../constants";
 
 import "./styles.css";
 import useOnBottomScroll from "../../hooks/useOnBottomScroll";
@@ -111,7 +111,7 @@ export const NotificationFeed: React.FC<NotificationFeedProps> = ({
           <Dropdown value={status} onChange={(e) => setStatus(e.target.value)}>
             {OrderedFilterStatuses.map((filterStatus) => (
               <option key={filterStatus} value={filterStatus}>
-                {FilterStatusToLabel[filterStatus]}
+                {t(filterStatus)}
               </option>
             ))}
           </Dropdown>

--- a/src/components/NotificationFeed/NotificationFeed.tsx
+++ b/src/components/NotificationFeed/NotificationFeed.tsx
@@ -17,6 +17,7 @@ import { ColorMode, FilterStatus, FilterStatusToLabel } from "../../constants";
 import "./styles.css";
 import useOnBottomScroll from "../../hooks/useOnBottomScroll";
 import useFeedSettings from "../../hooks/useFeedSettings";
+import { useTranslations } from "../../hooks/useTranslations";
 
 export type OnNotificationClick = (item: FeedItem) => void;
 export type RenderItem = ({ item }: RenderItemProps) => ReactNode;
@@ -66,6 +67,7 @@ export const NotificationFeed: React.FC<NotificationFeedProps> = ({
   const [status, setStatus] = useState(initialFilterStatus);
   const { feedClient, useFeedStore, colorMode } = useKnockFeed();
   const { settings } = useFeedSettings(feedClient);
+  const { t } = useTranslations();
 
   const { pageInfo, items, networkStatus } = useFeedStore();
   const containerRef = useRef<HTMLDivElement>(null);
@@ -103,7 +105,9 @@ export const NotificationFeed: React.FC<NotificationFeedProps> = ({
     >
       <header className="rnf-notification-feed__header">
         <div className="rnf-notification-feed__selector">
-          <span className="rnf-notification-feed__type">Notifications</span>
+          <span className="rnf-notification-feed__type">
+            {t("notifications")}
+          </span>
           <Dropdown value={status} onChange={(e) => setStatus(e.target.value)}>
             {OrderedFilterStatuses.map((filterStatus) => (
               <option key={filterStatus} value={filterStatus}>
@@ -137,7 +141,7 @@ export const NotificationFeed: React.FC<NotificationFeedProps> = ({
       {settings?.features.branding_required && (
         <div className="rnf-notification-feed__knock-branding">
           <a href={poweredByKnockUrl} target="_blank">
-            Powered by Knock
+            {t("poweredBy")}
           </a>
         </div>
       )}

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -5,10 +5,4 @@ export enum FilterStatus {
   Unread = "unread",
 }
 
-export const FilterStatusToLabel = {
-  [FilterStatus.All]: "All",
-  [FilterStatus.Unread]: "Unread",
-  [FilterStatus.Read]: "Read",
-};
-
 export type ColorMode = "light" | "dark";

--- a/src/hooks/useTranslations.ts
+++ b/src/hooks/useTranslations.ts
@@ -1,0 +1,22 @@
+import { useContext } from "react";
+import { Locale } from "date-fns";
+import * as dateFnsLocales from "date-fns/locale";
+import { Translation, i18n } from "../i18n";
+import { I18nContext } from "../components/KnockI18nProvider";
+
+export function useTranslations() {
+  const { translations, lang } = useContext<Translation>(I18nContext);
+
+  return {
+    lang,
+    t: (key: keyof typeof translations) => {
+      // We always use english as the default translation when a key doesn't exist
+      return translations[key] || i18n.en.translations[key];
+    },
+    dateFnsLocale: (): Locale => {
+      return lang in dateFnsLocales
+        ? dateFnsLocales[lang]
+        : dateFnsLocales.enUS;
+    },
+  };
+}

--- a/src/hooks/useTranslations.ts
+++ b/src/hooks/useTranslations.ts
@@ -1,21 +1,21 @@
 import { useContext } from "react";
-import { Locale } from "date-fns";
+import { Locale as DateFnLocale } from "date-fns";
 import * as dateFnsLocales from "date-fns/locale";
-import { Translation, i18n } from "../i18n";
+import { I18nContent, locales } from "../i18n";
 import { I18nContext } from "../components/KnockI18nProvider";
 
 export function useTranslations() {
-  const { translations, lang } = useContext<Translation>(I18nContext);
+  const { translations, locale } = useContext<I18nContent>(I18nContext);
 
   return {
-    lang,
+    locale,
     t: (key: keyof typeof translations) => {
       // We always use english as the default translation when a key doesn't exist
-      return translations[key] || i18n.en.translations[key];
+      return translations[key] || locales.en.translations[key];
     },
-    dateFnsLocale: (): Locale => {
-      return lang in dateFnsLocales
-        ? dateFnsLocales[lang]
+    dateFnsLocale: (): DateFnLocale => {
+      return locale in dateFnsLocales
+        ? dateFnsLocales[locale]
         : dateFnsLocales.enUS;
     },
   };

--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -1,0 +1,17 @@
+import en from "./languages/en";
+
+export interface Translations {
+  readonly emptyFeedTitle: string;
+  readonly emptyFeedBody: string;
+  readonly notifications: string;
+  readonly poweredBy: string;
+  readonly markAllAsRead: string;
+  readonly archiveNotification: string;
+}
+
+export interface Translation {
+  readonly translations: Partial<Translations>;
+  readonly lang: string;
+}
+
+export const i18n = { en };

--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -7,6 +7,10 @@ export interface Translations {
   readonly poweredBy: string;
   readonly markAllAsRead: string;
   readonly archiveNotification: string;
+  readonly all: string;
+  readonly unread: string;
+  readonly read: string;
+  readonly unseen: string;
 }
 
 export interface Translation {

--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -15,7 +15,7 @@ export interface Translations {
 
 export interface Translation {
   readonly translations: Partial<Translations>;
-  readonly lang: string;
+  readonly locale: string;
 }
 
-export const i18n = { en };
+export const locales = { en };

--- a/src/i18n/languages/en.ts
+++ b/src/i18n/languages/en.ts
@@ -1,6 +1,6 @@
-import { Translation } from "..";
+import { I18nContent } from "..";
 
-const en: Translation = {
+const en: I18nContent = {
   translations: {
     archiveNotification: "Archive this notification",
     markAllAsRead: "Mark all as read",
@@ -12,7 +12,7 @@ const en: Translation = {
     read: "Read",
     unseen: "Unseen",
   },
-  lang: "en",
+  locale: "en",
 };
 
 export default en;

--- a/src/i18n/languages/en.ts
+++ b/src/i18n/languages/en.ts
@@ -7,6 +7,10 @@ const en: Translation = {
     notifications: "Notifications",
     emptyFeedTitle: "No notifications yet",
     emptyFeedBody: "We'll let you know when we've got something new for you.",
+    all: "All",
+    unread: "Unread",
+    read: "Read",
+    unseen: "Unseen",
   },
   lang: "en",
 };

--- a/src/i18n/languages/en.ts
+++ b/src/i18n/languages/en.ts
@@ -1,0 +1,14 @@
+import { Translation } from "..";
+
+const en: Translation = {
+  translations: {
+    archiveNotification: "Archive this notification",
+    markAllAsRead: "Mark all as read",
+    notifications: "Notifications",
+    emptyFeedTitle: "No notifications yet",
+    emptyFeedBody: "We'll let you know when we've got something new for you.",
+  },
+  lang: "en",
+};
+
+export default en;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,15 +1,26 @@
 import { FeedClientOptions } from "@knocklabs/client";
-import { parseISO, formatDistance } from "date-fns";
+import { parseISO, formatDistance, Locale } from "date-fns";
 import { ReactNode } from "react";
 
 export function formatBadgeCount(count: number): string | number {
   return count > 9 ? "9+" : count;
 }
 
-export function formatTimestamp(ts: string) {
+type FormatTimestampOptions = {
+  locale?: Locale;
+};
+
+export function formatTimestamp(
+  ts: string,
+  options: FormatTimestampOptions = {}
+) {
   try {
     const parsedTs = parseISO(ts);
-    const formatted = formatDistance(parsedTs, new Date(), { addSuffix: true });
+    const formatted = formatDistance(parsedTs, new Date(), {
+      addSuffix: true,
+      locale: options.locale,
+    });
+
     return formatted;
   } catch (e) {
     return ts;
@@ -32,7 +43,13 @@ export function feedProviderKey(
   userFeedId: string,
   options: FeedClientOptions = {}
 ) {
-  return [userFeedId, options.source, options.tenant, options.has_tenant, options.archived]
+  return [
+    userFeedId,
+    options.source,
+    options.tenant,
+    options.has_tenant,
+    options.archived,
+  ]
     .filter((f) => f !== null && f !== undefined)
     .join("-");
 }


### PR DESCRIPTION
* added new `KnockI18nProvider` as a component that's rendered under the 
* added support for `useTranslations` hook
* replaced all copy with a translated variant through the new `t` helper
* added support for passing a locale to the `formatTimestamp` function

### Translations shape

The translations object has the following shape:

```
export interface Translations {
  readonly emptyFeedTitle: string;
  readonly emptyFeedBody: string;
  readonly notifications: string;
  readonly poweredBy: string;
  readonly markAllAsRead: string;
  readonly archiveNotification: string;
  readonly all: string;
  readonly unread: string;
  readonly read: string;
  readonly unseen: string;
}
```