### PR TITLE
chore: move to use markAllAsRead

### DIFF
--- a/src/components/NotificationFeed/MarkAsRead.tsx
+++ b/src/components/NotificationFeed/MarkAsRead.tsx
@@ -22,7 +22,7 @@ export const MarkAsRead: React.FC<MarkAsReadProps> = ({ onClick }) => {
 
   const onClickHandler = React.useCallback(
     (e: React.MouseEvent) => {
-      feedClient.markAsRead(unreadItems);
+      feedClient.markAllAsRead();
       if (onClick) onClick(e, unreadItems);
     },
     [feedClient, unreadItems, onClick]


### PR DESCRIPTION
We're currently using the `markAsRead` which takes a list of items to batch mark them as read. We introduced a new `markAllAsRead` which _bulk marks everything_ on the channel as read (and optimistically updates the store). This change moves to use that method instead, which fixes any issues where large numbers of unread items would never get updated.