### PR TITLE
fix: type exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "./dist/index.css": "./dist/index.css",
     ".": {
       "require": "./dist/cjs/index.js",
-      "default": "./dist/esm/index.js"
+      "default": "./dist/esm/index.js",
+      "types": "./dist/types/index.d.ts"
     }
   },
   "files": [


### PR DESCRIPTION
Add type exports to the package.json file. 

More info: [microsoft/Typescript#52363](https://github.com/microsoft/TypeScript/issues/52363)

This fixes following issue:
`Could not find a declaration file for module '@knocklabs/react-notification-feed'. 'z:/notifications-system/node_modules/@knocklabs/react-notification-feed/dist/esm/index.js' implicitly has an 'any' type.
  There are types at 'z:/notifications-system/node_modules/@knocklabs/react-notification-feed/dist/types/index.d.ts', but this result could not be resolved when respecting package.json "exports". The '@knocklabs/react-notification-feed' library may need to update its package.json or typings.ts(7016)`