### PR TITLE
fix: "Module not found: Error: Default condition should be last one"

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,8 +11,8 @@
     "./dist/index.css": "./dist/index.css",
     ".": {
       "require": "./dist/cjs/index.js",
-      "default": "./dist/esm/index.js",
-      "types": "./dist/types/index.d.ts"
+      "types": "./dist/types/index.d.ts",
+      "default": "./dist/esm/index.js"
     }
   },
   "files": [


### PR DESCRIPTION
Change the order of exports in package.json to fix this issue. default should be the last export.

https://stackoverflow.com/a/76127619