### PR TITLE
feat: introduce new  prop for customizing the feed header

### DIFF
--- a/src/components/NotificationFeed/Dropdown.tsx
+++ b/src/components/NotificationFeed/Dropdown.tsx
@@ -9,7 +9,11 @@ export type DropdownProps = {
   onChange: (e: any) => void;
 };
 
-const Dropdown: React.FC<DropdownProps> = ({ children, value, onChange }) => {
+export const Dropdown: React.FC<DropdownProps> = ({
+  children,
+  value,
+  onChange,
+}) => {
   const { colorMode } = useKnockFeed();
 
   return (
@@ -21,5 +25,3 @@ const Dropdown: React.FC<DropdownProps> = ({ children, value, onChange }) => {
     </div>
   );
 };
-
-export default Dropdown;

--- a/src/components/NotificationFeed/NotificationFeed.tsx
+++ b/src/components/NotificationFeed/NotificationFeed.tsx
@@ -12,14 +12,15 @@ import { useKnockFeed } from "../KnockFeedProvider";
 import { Spinner } from "../Spinner";
 import { NotificationCell } from "../NotificationCell";
 import { ColorMode, FilterStatus } from "../../constants";
+import {
+  NotificationFeedHeader,
+  NotificationFeedHeaderProps,
+} from "./NotificationFeedHeader";
 
 import "./styles.css";
 import useOnBottomScroll from "../../hooks/useOnBottomScroll";
 import useFeedSettings from "../../hooks/useFeedSettings";
 import { useTranslations } from "../../hooks/useTranslations";
-import NotificationFeedHeader, {
-  NotificationFeedHeaderProps,
-} from "./NotificationFeedHeader";
 
 export type OnNotificationClick = (item: FeedItem) => void;
 export type RenderItem = ({ item }: RenderItemProps) => ReactNode;

--- a/src/components/NotificationFeed/NotificationFeed.tsx
+++ b/src/components/NotificationFeed/NotificationFeed.tsx
@@ -1,5 +1,6 @@
 import { FeedItem, isRequestInFlight, NetworkStatus } from "@knocklabs/client";
 import React, {
+  ReactElement,
   ReactNode,
   useCallback,
   useEffect,
@@ -10,14 +11,15 @@ import { EmptyFeed } from "../EmptyFeed";
 import { useKnockFeed } from "../KnockFeedProvider";
 import { Spinner } from "../Spinner";
 import { NotificationCell } from "../NotificationCell";
-import { MarkAsRead } from "./MarkAsRead";
-import Dropdown from "./Dropdown";
 import { ColorMode, FilterStatus } from "../../constants";
 
 import "./styles.css";
 import useOnBottomScroll from "../../hooks/useOnBottomScroll";
 import useFeedSettings from "../../hooks/useFeedSettings";
 import { useTranslations } from "../../hooks/useTranslations";
+import NotificationFeedHeader, {
+  NotificationFeedHeaderProps,
+} from "./NotificationFeedHeader";
 
 export type OnNotificationClick = (item: FeedItem) => void;
 export type RenderItem = ({ item }: RenderItemProps) => ReactNode;
@@ -28,6 +30,7 @@ export type RenderItemProps = {
 
 export interface NotificationFeedProps {
   EmptyComponent?: ReactNode;
+  header?: ReactElement<NotificationFeedHeaderProps>;
   renderItem?: RenderItem;
   onNotificationClick?: OnNotificationClick;
   onMarkAllAsReadClick?: (e: React.MouseEvent, unreadItems: FeedItem[]) => void;
@@ -48,12 +51,6 @@ const LoadingSpinner = ({ colorMode }: { colorMode: ColorMode }) => (
   </div>
 );
 
-const OrderedFilterStatuses = [
-  FilterStatus.All,
-  FilterStatus.Unread,
-  FilterStatus.Read,
-];
-
 const poweredByKnockUrl =
   "https://knock.app?utm_source=powered-by-knock&utm_medium=referral&utm_campaign=knock-branding-feed";
 
@@ -63,6 +60,7 @@ export const NotificationFeed: React.FC<NotificationFeedProps> = ({
   onNotificationClick,
   onMarkAllAsReadClick,
   initialFilterStatus = FilterStatus.All,
+  header = NotificationFeedHeader,
 }) => {
   const [status, setStatus] = useState(initialFilterStatus);
   const { feedClient, useFeedStore, colorMode } = useKnockFeed();
@@ -103,21 +101,11 @@ export const NotificationFeed: React.FC<NotificationFeedProps> = ({
     <div
       className={`rnf-notification-feed rnf-notification-feed--${colorMode}`}
     >
-      <header className="rnf-notification-feed__header">
-        <div className="rnf-notification-feed__selector">
-          <span className="rnf-notification-feed__type">
-            {t("notifications")}
-          </span>
-          <Dropdown value={status} onChange={(e) => setStatus(e.target.value)}>
-            {OrderedFilterStatuses.map((filterStatus) => (
-              <option key={filterStatus} value={filterStatus}>
-                {t(filterStatus)}
-              </option>
-            ))}
-          </Dropdown>
-        </div>
-        <MarkAsRead onClick={onMarkAllAsReadClick} />
-      </header>
+      {React.cloneElement(header as ReactElement<NotificationFeedHeaderProps>, {
+        onMarkAllAsReadClick,
+        filterStatus: status,
+        setFilterStatus: setStatus,
+      })}
 
       <div className="rnf-notification-feed__container" ref={containerRef}>
         {networkStatus === NetworkStatus.loading && (

--- a/src/components/NotificationFeed/NotificationFeedHeader.tsx
+++ b/src/components/NotificationFeed/NotificationFeedHeader.tsx
@@ -1,0 +1,50 @@
+import React, { SetStateAction } from "react";
+import { FeedItem } from "@knocklabs/client";
+
+import { FilterStatus } from "../../constants";
+import { useTranslations } from "../../hooks/useTranslations";
+import Dropdown from "./Dropdown";
+import { MarkAsRead } from "./MarkAsRead";
+
+export type NotificationFeedHeaderProps = {
+  filterStatus: FilterStatus;
+  setFilterStatus: React.Dispatch<SetStateAction<FilterStatus>>;
+  onMarkAllAsReadClick: (e: React.MouseEvent, unreadItems: FeedItem[]) => void;
+};
+
+const OrderedFilterStatuses = [
+  FilterStatus.All,
+  FilterStatus.Unread,
+  FilterStatus.Read,
+];
+
+const NotificationFeedHeader: React.FC<NotificationFeedHeaderProps> = ({
+  onMarkAllAsReadClick,
+  filterStatus,
+  setFilterStatus,
+}) => {
+  const { t } = useTranslations();
+
+  return (
+    <header className="rnf-notification-feed__header">
+      <div className="rnf-notification-feed__selector">
+        <span className="rnf-notification-feed__type">
+          {t("notifications")}
+        </span>
+        <Dropdown
+          value={filterStatus}
+          onChange={(e) => setFilterStatus(e.target.value)}
+        >
+          {OrderedFilterStatuses.map((filterStatus) => (
+            <option key={filterStatus} value={filterStatus}>
+              {t(filterStatus)}
+            </option>
+          ))}
+        </Dropdown>
+      </div>
+      <MarkAsRead onClick={onMarkAllAsReadClick} />
+    </header>
+  );
+};
+
+export default NotificationFeedHeader;

--- a/src/components/NotificationFeed/NotificationFeedHeader.tsx
+++ b/src/components/NotificationFeed/NotificationFeedHeader.tsx
@@ -3,7 +3,7 @@ import { FeedItem } from "@knocklabs/client";
 
 import { FilterStatus } from "../../constants";
 import { useTranslations } from "../../hooks/useTranslations";
-import Dropdown from "./Dropdown";
+import { Dropdown } from "./Dropdown";
 import { MarkAsRead } from "./MarkAsRead";
 
 export type NotificationFeedHeaderProps = {
@@ -18,7 +18,7 @@ const OrderedFilterStatuses = [
   FilterStatus.Read,
 ];
 
-const NotificationFeedHeader: React.FC<NotificationFeedHeaderProps> = ({
+export const NotificationFeedHeader: React.FC<NotificationFeedHeaderProps> = ({
   onMarkAllAsReadClick,
   filterStatus,
   setFilterStatus,
@@ -46,5 +46,3 @@ const NotificationFeedHeader: React.FC<NotificationFeedHeaderProps> = ({
     </header>
   );
 };
-
-export default NotificationFeedHeader;

--- a/src/components/NotificationFeed/index.ts
+++ b/src/components/NotificationFeed/index.ts
@@ -1,2 +1,3 @@
 export * from "./NotificationFeed";
+export * from "./NotificationFeedHeader";
 export * from "./MarkAsRead";


### PR DESCRIPTION
Adds the ability to override the `header` rendered in the NotificationFeed. Defaults to the `NotificationFeedHeader` component that's rendered.

Usage:

```
<NotificationFeed
  header={<NotificationFeedHeader />}
/>
```