### PR TITLE
Types children props on Knock Feed Container

### DIFF
--- a/src/components/KnockFeedProvider/KnockFeedContainer.tsx
+++ b/src/components/KnockFeedProvider/KnockFeedContainer.tsx
@@ -1,8 +1,8 @@
 import React from "react";
 import "./styles.css";
 
-export const KnockFeedContainer: React.FC = ({ children }) => {
-  return (
-    <div className="rnf-feed-provider">{children}</div>
-  );
+export const KnockFeedContainer: React.FC<{
+  children: React.ReactNode;
+}> = ({ children }) => {
+  return <div className="rnf-feed-provider">{children}</div>;
 };


### PR DESCRIPTION
I can't use the Knock Feed Container in our repo as typescript doesn't consider it to have a typed child prop so added a one 