### PR TITLE
fix: show archive button on all touch screen devices

### DIFF
--- a/src/components/NotificationCell/styles.css
+++ b/src/components/NotificationCell/styles.css
@@ -229,7 +229,7 @@
   background-color: #565a61;
 }
 
-@media screen and (max-width: 400px) {
+@media screen and (hover: none) {
   .rnf-archive-notification-btn {
     opacity: 1;
   }


### PR DESCRIPTION
Shows the archive button for all touch screen devices rather than relying on a set screen width. 

![IMG_69791E8F1C48-1](https://github.com/knocklabs/react-notification-feed/assets/12838032/ecaf5ca1-ce61-41bb-bb1a-7a77fa2b504f)

